### PR TITLE
fix(ios): implement mount/unmount methods for stable marker removal

### DIFF
--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -784,6 +784,16 @@ using namespace facebook::react;
     [super removeReactSubview: subview];
 }
 
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+    [self insertSubview:childComponentView atIndex:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+    [self removeReactSubview:childComponentView];
+}
+
 - (void)setClusterColor: (NSNumber*) color {
     clusterColor = [RCTConvert UIColor:color];
 }


### PR DESCRIPTION
## Проблема
При удалении маркеров из массива они остаются на карте. Воспроизводится только на iOS.

## Решение
Реализованы методы `mountChildComponentView` и `unmountChildComponentView` 
в `YamapView` для корректной обработки жизненного цикла дочерних компонентов 
в новой архитектуре React Native (Fabric).

**До (использовалась версия 5.3.1):**
<video src="https://github.com/user-attachments/assets/f5e2f210-6832-4309-819f-c77e88af62a4" controls width="640" height="360"></video>

**После:**
<video src="https://github.com/user-attachments/assets/04b39ef1-fda6-48aa-baca-5f829117ef63" controls width="640" height="360"></video>