### PR TITLE
fix: marker rendering issues with remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,47 @@ import {Yamap, Marker} from 'react-native-yamap-plus';
 #### Доступные методы для примитива **Marker**:
 
 -  `animatedMoveTo(point: Point, duration: number)` - плавное изменение позиции маркера;
--  `animatedRotateTo(angle: number, duration: number)` - плавное вращение маркера.
+-  `animatedRotateTo(angle: number, duration: number)` - плавное вращение маркера;
+-  `updateMarker()` - принудительное обновление snapshot маркера (см. раздел ниже).
+
+#### Работа с асинхронным содержимым маркеров
+
+Если маркер содержит компоненты, которые загружаются асинхронно (например, изображения, загружаемые по URL), необходимо вызывать метод `updateMarker()` после завершения загрузки. Это связано с тем, что snapshot маркера создается один раз при монтировании, и не обновляется автоматически при изменении содержимого.
+
+**Пример с изображением по URL:**
+
+```tsx
+import { useRef } from 'react';
+import { Image } from 'react-native';
+import { Yamap, Marker, type MarkerRef } from 'react-native-yamap-plus';
+
+function MapWithAsyncMarker() {
+  const markerRef = useRef<MarkerRef>(null);
+
+  return (
+    <Yamap>
+      <Marker
+        ref={markerRef}
+        point={{ lat: 55.751244, lon: 37.618423 }}
+        anchor={{ x: 0.5, y: 0.5 }}
+      >
+        <Image
+          source={{ uri: 'https://example.com/marker-icon.png' }}
+          style={{ width: 100, height: 100 }}
+          onLoad={() => {
+            // Вызываем updateMarker после загрузки изображения
+            markerRef.current?.updateMarker();
+          }}
+        />
+      </Marker>
+    </Yamap>
+  );
+}
+```
+
+**Важно:** 
+- Метод `updateMarker()` автоматически выполняется два раза: сразу после вызовы и с небольшой задержкой для надёжности.
+- Это применимо не только к изображениям, но и к любым компонентам, которые должны быть обновлены.
 
 ### Circle
 

--- a/android/src/main/java/ru/yamap/view/MarkerViewManager.kt
+++ b/android/src/main/java/ru/yamap/view/MarkerViewManager.kt
@@ -73,6 +73,11 @@ class MarkerViewManager : ViewGroupManager<MarkerView>(), MarkerViewManagerInter
     }
 
     override fun receiveCommand(view: MarkerView, commandType: String, argsArr: ReadableArray?) {
+        if (commandType == "updateMarker") {
+            view.onUpdateMarker()
+            return
+        }
+
         val args = argsArr?.getArray(0)?.getMap(0) ?: return
 
         when (commandType) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2506,7 +2506,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNYamap (6.1.0):
+  - RNYamap (6.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2795,7 +2795,7 @@ SPEC CHECKSUMS:
   FBLazyVector: d7f74537f87b148a7bb047c690036ce7a52c7590
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: c6973ea6e0b9ffaaa29756a6a499b24fc9f6782b
+  hermes-engine: c0554cd02727cd18e509c063b011730034b1ad42
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: fd7dda582e035270b441eec37e0d59f9a93f4cd1
   RCTRequired: 8769adc104cdfa26af6a42152b3d355d62cd016f
@@ -2866,7 +2866,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 03fa265b76d2bb90996e2536fde27faba58ee296
   ReactCommon: 52d5fa3b83bb78ac8eedefa5d8e659d18bfa9eeb
   RNSVG: 9b6fe43a957af361c17f45f95cba726bfa73487f
-  RNYamap: f122d1b46dce0f9bdcba175252927c5effccd93d
+  RNYamap: 1d06c71863489b4d2f5993df9afbdaca21c73625
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   YandexMapsMobile: 763ceef6cb921898894ff2b684e4336967804ac7
   Yoga: cec68ad2cff7afc3e8f47ad6a056aa4b084cd1ac

--- a/example/src/screens/MapScreen.tsx
+++ b/example/src/screens/MapScreen.tsx
@@ -1,13 +1,14 @@
-import React, {useEffect, useRef, useState} from 'react';
-import {StyleSheet} from 'react-native';
-import {Circle, Marker, MarkerRef, Polyline, Yamap, YamapRef} from '../../../';
-import {Polygon} from '../../../src';
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Image } from 'react-native';
+import { Circle, Marker, MarkerRef, Polyline, Yamap, YamapRef } from '../../../';
+import { Polygon } from '../../../src';
 import MarkerIcon from '../assets/images/marker.svg';
 
 export const MapScreen = () => {
   const [mapLoaded, setMapLoaded] = useState(false);
   const mapRef = useRef<YamapRef | null>(null);
   const markerRef = useRef<MarkerRef | null>(null);
+  const urlImageTestMarkerRef = useRef<MarkerRef | null>(null);
   const angleRef = useRef(0);
 
   const [dashLength, setDashLength] = useState(15);
@@ -82,6 +83,23 @@ export const MapScreen = () => {
         anchor={{x: 0.5, y: 1}}
       >
         <MarkerIcon width={100} height={100} />
+      </Marker>
+      <Marker
+        ref={urlImageTestMarkerRef}
+        point={{ lat: 55.80, lon: 37.618423 }}
+        anchor={{ x: 0.5, y: 0.5 }}
+      >
+        <Image
+          source={{ uri: 'https://placehold.co/100x100.png' }}
+          style={styles.urlImageTestMarkerRef}
+          onLoad={() => {
+            console.log('Test marker image loaded, updating marker...');
+            urlImageTestMarkerRef.current?.updateMarker();
+          }}
+          onError={(e) => {
+            console.log('Test marker image load error', e.nativeEvent);
+          }}
+        />
       </Marker>
       <Circle
         center={{lat: 55.74, lon: 37.64}}
@@ -161,4 +179,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  urlImageTestMarkerRef: {
+    width: 100,
+    height: 100,
+    borderRadius: 10,
+    borderWidth: 3,
+    borderColor: 'blue'
+  }
 });

--- a/ios/View/MarkerView.mm
+++ b/ios/View/MarkerView.mm
@@ -116,6 +116,8 @@ using namespace facebook::react;
     handled = NO;
     source = nil;
     lastSource = nil;
+    // Fix for recycling bug: Ensure the provider is cleared so old icons don't persist
+    _markerViewProvider = nil;
     _reactSubviews = [[NSMutableArray alloc] init];
 }
 

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -13,18 +13,21 @@ export type MarkerProps = OmitEx<MarkerNativeProps, 'source' | 'zI'> &  {
 export interface MarkerRef {
   animatedMoveTo: (coords: Point, duration: number) => void;
   animatedRotateTo: (angle: number, duration: number) => void;
+  updateMarker: () => void;
 }
 
-export const Marker = forwardRef<MarkerRef, MarkerProps>(({source, zIndex, visible = true, ...props}, ref) => {
+export const Marker = forwardRef<MarkerRef, MarkerProps>(({ source, zIndex, visible = true, ...props }, ref) => {
   const nativeRef = useRef(null);
 
   const imageUri = useMemo(() => getImageUri(source), [source]);
 
   useImperativeHandle<MarkerRef, any>(ref, () => ({
     animatedMoveTo: (coords: Point, duration: number) =>
-      Commands.animatedMoveTo(nativeRef.current!, [{coords, duration}]),
+      Commands.animatedMoveTo(nativeRef.current!, [{ coords, duration }]),
     animatedRotateTo: (angle: number, duration: number) =>
-      Commands.animatedRotateTo(nativeRef.current!, [{angle, duration}]),
+      Commands.animatedRotateTo(nativeRef.current!, [{ angle, duration }]),
+    updateMarker: () =>
+      Commands.updateMarker(nativeRef.current!),
   }), []);
 
   return (

--- a/src/spec/commands/marker.ts
+++ b/src/spec/commands/marker.ts
@@ -7,11 +7,11 @@ import {type Point} from '../../interfaces';
 export interface MarkerNativeCommands {
   animatedMoveTo: (
     viewRef: React.ElementRef<MarkerComponentType>,
-    args: Array<Readonly<{ coords: Point, duration: Double }>>
+    args: Array<Readonly<{coords: Point, duration: Double}>>
   ) => void;
   animatedRotateTo: (
     viewRef: React.ElementRef<MarkerComponentType>,
-    args: Array<Readonly<{ angle: Float, duration: Double }>>
+    args: Array<Readonly<{angle: Float, duration: Double}>>
   ) => void;
   updateMarker: (
     viewRef: React.ElementRef<MarkerComponentType>,

--- a/src/spec/commands/marker.ts
+++ b/src/spec/commands/marker.ts
@@ -7,11 +7,14 @@ import {type Point} from '../../interfaces';
 export interface MarkerNativeCommands {
   animatedMoveTo: (
     viewRef: React.ElementRef<MarkerComponentType>,
-    args: Array<Readonly<{coords: Point, duration: Double}>>
+    args: Array<Readonly<{ coords: Point, duration: Double }>>
   ) => void;
   animatedRotateTo: (
     viewRef: React.ElementRef<MarkerComponentType>,
-    args: Array<Readonly<{angle: Float, duration: Double}>>
+    args: Array<Readonly<{ angle: Float, duration: Double }>>
+  ) => void;
+  updateMarker: (
+    viewRef: React.ElementRef<MarkerComponentType>,
   ) => void;
 }
 
@@ -19,5 +22,6 @@ export const Commands = codegenNativeCommands<MarkerNativeCommands>({
   supportedCommands: [
     'animatedMoveTo',
     'animatedRotateTo',
+    'updateMarker',
   ],
 });


### PR DESCRIPTION
## Проблемы

### Основная проблема (обе платформы)
Маркеры с изображениями, загружаемыми по сети (URL), не отображаются при первом рендере, если не были ранее закэшированы. Это происходит из-за того, что snapshot маркера выполнялся один раз в момент монтирования, когда изображение ещё не загружено и не обновляется после.

### Сопутствующие проблемы
1. **Android:** Изображения вообще не отображаются в маркерах, даже если уже в кэше. Библиотека Fresco не начинает загрузку, так как дочерние View не прикреплены к иерархии окна.
2. **iOS:** При открытии карты на месте нового маркера иногда отображался другой маркер из кэша (recycling issue).

#### Демонстрация проблем:
<video src="https://github.com/user-attachments/assets/b037a6a4-8431-435c-847a-949ac0c5469c" controls width="640" height="360"></video>
Видно, что на iOS при втором рендере изображение отображается, т.к. закэшированно, а на android никогда не появляется.

Демо проблемы на iOS с отображением случайных маркеров на месте пустых:
Здесь несколько маркеров: сначала они пустые, потом по таймеру в них отрисовывются компоненты. Сами маркеры всегда смонтированы:
<video src="https://github.com/user-attachments/assets/546e7fd7-e16f-4523-b219-988a111ce521" controls width="640" height="360"></video>

## Решение

### Сопутствующих проблем

Сперва имеет смысл решить их, прежде чем перейти к основной.

#### 1. Android: Прикрепление к иерархии View
**Коммит:** `fix(android): attach marker children to view hierarchy for Fresco`

*   `MarkerView` теперь добавляет дочерние элементы в иерархию View через `addView()` и имеет `visibility = INVISIBLE`.
*   Добавлена принудительная проверка размеров с вызовом `measure()` и `layout()` перед созданием snapshot.

Это позволяет библиотеке Fresco корректно загружать изображения, так как View считается "прикрепленным к окну". Теперь отображаются изображения, сохранённые в кэше.

#### 2. iOS: Очистка кэша при переиспользовании
**Коммит:** `fix(ios): clear marker provider on recycle to prevent icon swapping`

*   В методе `prepareForRecycle` добавлена очистка `_markerViewProvider = nil`.

Это устраняет проблему отображения старого закэшированного содержимого других маркеров в новых пустых маркерах.

### Основнойпроблемы

#### iOS: Метод принудительной перерисовки маркера, авто-повтор после задержки
**Коммит:** `fix(ios): implement updateMarker with delay for async rendering`

*   Добавлена команда `updateMarker` в спецификацию Native Component (`src/spec/commands/marker.ts`).
*   Метод `updateMarker` экспортирован через `ref` компонента `Marker`.
*   Реализована команда `updateMarker` с задержкой (400ms) и `layoutIfNeeded`.

Это гарантирует создание snapshot после обновления компонента (загрузки и отрисовки изображения).

#### Android: Метод принудительной перерисовки маркера, авто-повтор после задержки
**Коммит:** `fix(android): implement updateMarker with delay for reliable rendering`

*   Реализована команда `updateMarker`
*   Добавлено задержка (400ms)

> **Для чего нужна задержка?**
>
> Без задержки snapshot часто создается до того, как изображение реально отрисовано в пикселях View. Событие `onLoad` в React Native сигнализирует о том, что изображение загружено в память, но процесс layout и draw (отрисовка на экране) происходит асинхронно в следующих кадрах.
>
> Задержка в 400ms дает системе достаточно времени для завершения всех процессов отрисовки. Это значение подобрано экспериментально как баланс между надёжностью (работает даже на слабых устройствах) и отзывчивостью (пользователь не замечает задержки).
>
> Также используется двойной вызов `updateMarker`: первый — сразу (для случаев, когда изображение уже в кэше и отрисовано мгновенно), второй — с задержкой (гарантия для асинхронных случаев).
>
> Считаю, что это спорное решение. Лучше обходиться без таймеров, если это возможно.
> В данном случае другого решения не нашлось.
> Можно было бы на стороне RN в onLoad методе добавлять задержку. Но было решено перенести её в нативный код для надёжности и удобства использования библиотеки.
>
> Если в будущем найдётся решение без использования таймера, следует использовать его для надёжности.

## Использование

Для маркеров с асинхронно загружаемым содержимым (например, изображения по URL) необходимо вызывать `updateMarker()` после завершения загрузки:

```tsx
import { useRef } from 'react';
import { Image } from 'react-native';
import { Marker, type MarkerRef } from 'react-native-yamap-plus';

function MapExample() {
  const markerRef = useRef<MarkerRef>(null);

  return (
    <Marker
      ref={markerRef}
      point={{ lat: 55.751244, lon: 37.618423 }}
      anchor={{ x: 0.5, y: 0.5 }}
    >
      <Image
        source={{ uri: 'https://example.com/marker-icon.png' }}
        style={{ width: 100, height: 100 }}
        onLoad={() => {
          // Вызываем updateMarker после загрузки изображения
          markerRef.current?.updateMarker();
        }}
      />
    </Marker>
  );
}
```

## Демонстрация результата
<video src="https://github.com/user-attachments/assets/1f6c6f0e-0537-45e1-813d-957f17bccd65" controls width="640" height="360"></video>
<video src="https://github.com/user-attachments/assets/e56bf35f-a2c3-405a-af0b-2e78e5172a73" controls width="640" height="360"></video>
 
> **Важно для корректного тестирования**
> Необходимо надёжно сбрасывать кэш изображений, чтобы отслеживать именно первый рендер
> Достаточно закрыть приложение, уствноить новые (которые ни разу ранее не использовались) размеры изображения в ссылке, запустить приложение. Простой перезапуск приложения, Metro - не всегда в достаточной степени очищает кэш.
