### PR TITLE
fix(android): handle marker source image render by file:// uri path

### DIFF
--- a/android/src/main/java/ru/yamap/utils/ImageCacheManager.kt
+++ b/android/src/main/java/ru/yamap/utils/ImageCacheManager.kt
@@ -32,6 +32,10 @@ class ImageCacheManager {
                 val bitmap = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.size)
 
                 return  bitmap
+            } else if (url.startsWith("file://")) {
+                val filePath = url.removePrefix("file://")
+                val bitmap = BitmapFactory.decodeFile(filePath)
+                return bitmap
             }
 
             val id = context.resources.getIdentifier(url, "drawable", context.packageName)


### PR DESCRIPTION
## Проблема
Ошибка декодирования изображений с URI "file://" (например, при использовании react-native-view-shot для снимков компонентов и передачи в source маркера).

## Решение
Добавлена обработка "file://" в методе декодирования: удаление префикса и загрузка через `BitmapFactory.decodeFile(filePath)`. Поддерживает локальные файлы для различных сценариев в React Native.

**До:**
Изображения с "file://" не обрабатывались, приводя к ошибкам.

**После:**
Корректная загрузка без ошибок.