### PR TITLE
Deprecate Marker children prop in favor of snapshot approach, docs

### DIFF
--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -5,9 +5,16 @@ import MarkerNativeComponent, {type MarkerNativeProps} from '../spec/MarkerNativ
 import {Commands} from '../spec/commands/marker';
 import {type Point} from '../interfaces';
 
-export type MarkerProps = OmitEx<MarkerNativeProps, 'source' | 'zI'> &  {
+export type MarkerProps = OmitEx<MarkerNativeProps, 'source' | 'zI' | 'children'> & {
   source?: ImageSourcePropType;
   zIndex?: number;
+
+  /**
+   * @deprecated
+   * Pass images into "source".
+   * To render components, take snapshots and pass them into "source".
+   */
+  children?: React.ReactNode;
 }
 
 export interface MarkerRef {
@@ -15,26 +22,28 @@ export interface MarkerRef {
   animatedRotateTo: (angle: number, duration: number) => void;
 }
 
-export const Marker = forwardRef<MarkerRef, MarkerProps>(({source, zIndex, visible = true, ...props}, ref) => {
+export const Marker = forwardRef<MarkerRef, MarkerProps>(({source, zIndex, visible = true, children, ...props}, ref) => {
   const nativeRef = useRef(null);
 
   const imageUri = useMemo(() => getImageUri(source), [source]);
 
   useImperativeHandle<MarkerRef, any>(ref, () => ({
     animatedMoveTo: (coords: Point, duration: number) =>
-      Commands.animatedMoveTo(nativeRef.current!, [{coords, duration}]),
+        Commands.animatedMoveTo(nativeRef.current!, [{coords, duration}]),
     animatedRotateTo: (angle: number, duration: number) =>
-      Commands.animatedRotateTo(nativeRef.current!, [{angle, duration}]),
+        Commands.animatedRotateTo(nativeRef.current!, [{angle, duration}]),
   }), []);
 
   return (
-    <MarkerNativeComponent
-      zI={zIndex}
-      {...props}
-      ref={nativeRef}
-      source={imageUri}
-      visible={visible}
-      pointerEvents="none"
-    />
+      <MarkerNativeComponent
+          zI={zIndex}
+          {...props}
+          ref={nativeRef}
+          source={imageUri}
+          visible={visible}
+          pointerEvents="none"
+      >
+        {children}
+      </MarkerNativeComponent>
   );
 });


### PR DESCRIPTION
В проекте, над которым работаю, все маркеры рендерились в виде компонентов через `children`. При приближении, при нажатии - вёрстка маркера менятся.

До некоторых пор это работало нормально, лишь с некоторыми особенностями в вёрстке.
Например:
- Глубоко вложенный текст в несколько View не отображался, приходилось менять вёрстку компонента
- Чтобы при смене стейта компонент перерисовался, нужно было менять key у компонента верхнего уровня в children

Но при попытке добавить в маркер компонент, который помимо своей вёрстки содержит Image, загружаемый по url - появились проблемы:
- При первом рендере маркера библиотека делала snapshot компонента, который ещё не успел загрузить изображение - вместо него была пустота.
- После завершения загрузки изображения маркер не обновлялся.
- Попытка обновить key в children по onLoad событию не увенчалась успехом.

Была [попытка](https://github.com/Qudaeo/react-native-yamap-plus/pull/19) добавить принудительно обновление маркера через ref. Это работает, но не лучшее решение. Изменение откатили.

**Причина**
Иследование показало: библиотека заточена под вывод множества одинаковых изображений (в source).

**Решение**
Описал в Readme: [делаем snapshot](https://github.com/gre/react-native-view-shot) и передаём в source.

Дополнительно в своём проекте я реализовал кэширование: для одинаковых маркеров снимок делается один раз и переиспользуется в source для всех копий.

**Результаты**
- Маркеры рендерятся корректно
- Нагрзука на процессор и память снизились

**Экстремальные тесты:**
- 10 000 маркеров: Время первичного рендера сократилось в 3 раза (6с → 2с). Карта перестала замирать на время рендера и остаётся отзывчивой. Потребление памяти снизилось с ~1.3гб до ~300мб.
100 000 маркеров: Если раньше приложение замирало полностью, то теперь рендерит их за 30с, отображает и почти не тормозит.
P.S. Это именно экстремальные тесты. На проде приложение отрисовывает всего несколько сотен маркеров без заметных задержек и фризов.