### PR TITLE
Feat/imperative cluster markers

### DIFF
--- a/android/src/main/java/ru/yamap/events/yamap/YamapClusterPlacemarkPressEvent.kt
+++ b/android/src/main/java/ru/yamap/events/yamap/YamapClusterPlacemarkPressEvent.kt
@@ -1,0 +1,27 @@
+package ru.yamap.events.yamap
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class YamapClusterPlacemarkPressEvent(
+    surfaceId: Int,
+    viewId: Int,
+    private val lat: Double,
+    private val lon: Double,
+    private val index: Int,
+) : Event<YamapClusterPlacemarkPressEvent>(surfaceId, viewId) {
+    override fun getEventName() = EVENT_NAME
+
+    override fun getCoalescingKey(): Short = 0
+
+    override fun getEventData(): WritableMap = Arguments.createMap().apply {
+        putDouble("lat", lat)
+        putDouble("lon", lon)
+        putInt("index", index)
+    }
+
+    companion object {
+        const val EVENT_NAME = "topClusterPlacemarkPress"
+    }
+}

--- a/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
+++ b/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
@@ -51,6 +51,51 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         clusterTextYOffset = offset
     }
 
+    fun appendClusterMarkers(points: ArrayList<HashMap<String, Double>>, iconSource: String?) {
+        if (points.isEmpty()) return
+        val pt = ArrayList<Point>()
+        for (p in points) {
+            pt.add(Point(p["lat"]!!, p["lon"]!!))
+        }
+
+        val addNow: (android.graphics.Bitmap?) -> Unit = { bitmap ->
+            val provider = if (bitmap != null) {
+                object : ImageProvider() {
+                    override fun getId(): String = "append_cluster_icon_${iconSource.hashCode()}"
+                    override fun getImage(): Bitmap = bitmap
+                }
+            } else {
+                TextImageProvider(points.size.toString())
+            }
+            val placemarks = clusterCollection.addPlacemarks(pt, provider, IconStyle())
+            pointsList.addAll(pt)
+            for (i in placemarks.indices) {
+                val placemark = placemarks[i]
+                placemarksMap["" + placemark.geometry.latitude + placemark.geometry.longitude] =
+                    placemark
+            }
+            clusterCollection.clusterPlacemarks(50.0, 12)
+        }
+
+        if (!iconSource.isNullOrEmpty()) {
+            val ctx = context ?: run { addNow(null); return }
+            try {
+                val bmp = ImageCacheManager.getBitmapSync(ctx, iconSource)
+                addNow(bmp)
+            } catch (_: Throwable) {
+                addNow(null)
+            }
+        } else {
+            addNow(null)
+        }
+    }
+
+    fun clearClusterMarkers() {
+        clusterCollection.clear()
+        placemarksMap.clear()
+        pointsList.clear()
+    }
+
     fun setClusteredMarkers(points: ArrayList<HashMap<String, Double>>) {
         clusterCollection.clear()
         placemarksMap.clear()

--- a/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
+++ b/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
@@ -8,21 +8,27 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.Typeface
 import android.view.View
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.UIManagerHelper.getSurfaceId
 import com.yandex.mapkit.geometry.Point
 import com.yandex.mapkit.map.Cluster
 import com.yandex.mapkit.map.ClusterListener
 import com.yandex.mapkit.map.ClusterTapListener
 import com.yandex.mapkit.map.IconStyle
+import com.yandex.mapkit.map.MapObject
+import com.yandex.mapkit.map.MapObjectTapListener
 import com.yandex.mapkit.map.PlacemarkMapObject
 import com.yandex.runtime.image.ImageProvider
 import kotlin.math.abs
 import kotlin.math.sqrt
 import androidx.core.graphics.createBitmap
 import com.facebook.react.bridge.ReadableMap
+import ru.yamap.events.yamap.YamapClusterPlacemarkPressEvent
 import ru.yamap.utils.ImageCacheManager
 
 class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListener,
-    ClusterTapListener {
+    ClusterTapListener, MapObjectTapListener {
     private val clusterCollection = mapWindow.map.mapObjects.addClusterizedPlacemarkCollection(this)
     private var clusterColor = 0
     private val placemarksMap = HashMap<String?, PlacemarkMapObject?>()
@@ -35,6 +41,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
     private var clusterTextXOffset = 0
     private var clusterTextYOffset = 0
     private var hasImperativePlacemarks = false
+    private val imperativeIndexMap = HashMap<PlacemarkMapObject, Int>()
+    private var imperativePlacemarkCounter = 0
 
     fun setClusterTextSize(size: Float) {
         clusterTextSize = size
@@ -79,6 +87,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
                 val placemark = placemarks[i]
                 placemarksMap["" + placemark.geometry.latitude + placemark.geometry.longitude] =
                     placemark
+                imperativeIndexMap[placemark] = imperativePlacemarkCounter++
+                placemark.addTapListener(this)
             }
             hasImperativePlacemarks = true
             if (recluster) {
@@ -100,6 +110,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         clusterCollection.clear()
         placemarksMap.clear()
         pointsList.clear()
+        imperativeIndexMap.clear()
+        imperativePlacemarkCounter = 0
         hasImperativePlacemarks = false
     }
 
@@ -110,6 +122,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         if (points.isEmpty() && hasImperativePlacemarks) return
         clusterCollection.clear()
         placemarksMap.clear()
+        imperativeIndexMap.clear()
+        imperativePlacemarkCounter = 0
         val pt = ArrayList<Point>()
         for (i in points.indices) {
             val point = points[i]
@@ -150,6 +164,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
 
     private fun updateUserMarkersColor() {
         clusterCollection.clear()
+        imperativeIndexMap.clear()
+        imperativePlacemarkCounter = 0
         val placemarks = clusterCollection.addPlacemarks(
             pointsList,
             TextImageProvider(pointsList.size.toString()),
@@ -204,6 +220,23 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
             points.add(placemark.geometry)
         }
         fitMarkers(points, 0.7f, 0)
+        return true
+    }
+
+    override fun onMapObjectTap(mapObject: MapObject, point: Point): Boolean {
+        if (mapObject !is PlacemarkMapObject) return false
+        val index = imperativeIndexMap[mapObject] ?: return false
+        val themedContext = context as? ThemedReactContext ?: return false
+        val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(themedContext, id) ?: return false
+        dispatcher.dispatchEvent(
+            YamapClusterPlacemarkPressEvent(
+                getSurfaceId(themedContext),
+                id,
+                point.latitude,
+                point.longitude,
+                index,
+            )
+        )
         return true
     }
 

--- a/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
+++ b/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.PointF
 import android.graphics.Rect
 import android.graphics.Typeface
 import android.view.View
@@ -63,6 +64,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
     fun appendClusterMarkers(
         points: ArrayList<HashMap<String, Double>>,
         iconSource: String?,
+        anchorX: Float?,
+        anchorY: Float?,
         recluster: Boolean,
     ) {
         if (points.isEmpty()) return
@@ -81,7 +84,11 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
             } else {
                 TextImageProvider("")
             }
-            val placemarks = clusterCollection.addPlacemarks(pt, provider, IconStyle())
+            val iconStyle = IconStyle()
+            if (anchorX != null && anchorY != null) {
+                iconStyle.anchor = PointF(anchorX, anchorY)
+            }
+            val placemarks = clusterCollection.addPlacemarks(pt, provider, iconStyle)
             pointsList.addAll(pt)
             for (i in placemarks.indices) {
                 val placemark = placemarks[i]

--- a/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
+++ b/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
@@ -34,6 +34,7 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
     private var clusterTextColor = Color.BLACK
     private var clusterTextXOffset = 0
     private var clusterTextYOffset = 0
+    private var hasImperativePlacemarks = false
 
     fun setClusterTextSize(size: Float) {
         clusterTextSize = size
@@ -51,7 +52,11 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         clusterTextYOffset = offset
     }
 
-    fun appendClusterMarkers(points: ArrayList<HashMap<String, Double>>, iconSource: String?) {
+    fun appendClusterMarkers(
+        points: ArrayList<HashMap<String, Double>>,
+        iconSource: String?,
+        recluster: Boolean,
+    ) {
         if (points.isEmpty()) return
         val pt = ArrayList<Point>()
         for (p in points) {
@@ -59,13 +64,14 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         }
 
         val addNow: (android.graphics.Bitmap?) -> Unit = { bitmap ->
-            val provider = if (bitmap != null) {
+            val provider = if (bitmap != null && !iconSource.isNullOrEmpty()) {
+                val id = "append_cluster_icon_$iconSource"
                 object : ImageProvider() {
-                    override fun getId(): String = "append_cluster_icon_${iconSource.hashCode()}"
+                    override fun getId(): String = id
                     override fun getImage(): Bitmap = bitmap
                 }
             } else {
-                TextImageProvider(points.size.toString())
+                TextImageProvider("")
             }
             val placemarks = clusterCollection.addPlacemarks(pt, provider, IconStyle())
             pointsList.addAll(pt)
@@ -74,16 +80,16 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
                 placemarksMap["" + placemark.geometry.latitude + placemark.geometry.longitude] =
                     placemark
             }
-            clusterCollection.clusterPlacemarks(50.0, 12)
+            hasImperativePlacemarks = true
+            if (recluster) {
+                clusterCollection.clusterPlacemarks(CLUSTER_RADIUS, CLUSTER_MIN_ZOOM)
+            }
         }
 
         if (!iconSource.isNullOrEmpty()) {
             val ctx = context ?: run { addNow(null); return }
-            try {
-                val bmp = ImageCacheManager.getBitmapSync(ctx, iconSource)
-                addNow(bmp)
-            } catch (_: Throwable) {
-                addNow(null)
+            ImageCacheManager.getImage(ctx, iconSource) { bitmap ->
+                addNow(bitmap)
             }
         } else {
             addNow(null)
@@ -94,9 +100,14 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         clusterCollection.clear()
         placemarksMap.clear()
         pointsList.clear()
+        hasImperativePlacemarks = false
     }
 
     fun setClusteredMarkers(points: ArrayList<HashMap<String, Double>>) {
+        // Empty prop arrives on every re-render when the consumer drives this
+        // component imperatively — never clear in that case, it would wipe the
+        // markers added via appendClusterMarkers.
+        if (points.isEmpty() && hasImperativePlacemarks) return
         clusterCollection.clear()
         placemarksMap.clear()
         val pt = ArrayList<Point>()
@@ -115,7 +126,8 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
                 child.setMarkerMapObject(placemark)
             }
         }
-        clusterCollection.clusterPlacemarks(50.0, 12)
+        hasImperativePlacemarks = false
+        clusterCollection.clusterPlacemarks(CLUSTER_RADIUS, CLUSTER_MIN_ZOOM)
     }
 
     fun setClusterIcon(source: String) {
@@ -152,7 +164,7 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
                 child.setMarkerMapObject(placemark)
             }
         }
-        clusterCollection.clusterPlacemarks(50.0, 12)
+        clusterCollection.clusterPlacemarks(CLUSTER_RADIUS, CLUSTER_MIN_ZOOM)
     }
 
     override fun addFeature(child: View?, index: Int) {
@@ -272,5 +284,7 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
         private const val FONT_SIZE = 45f
         private const val MARGIN_SIZE = 9f
         private const val STROKE_SIZE = 9f
+        private const val CLUSTER_RADIUS = 50.0
+        private const val CLUSTER_MIN_ZOOM = 12
     }
 }

--- a/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
+++ b/android/src/main/java/ru/yamap/view/ClusteredYamapView.kt
@@ -168,6 +168,10 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
     }
 
     override fun addFeature(child: View?, index: Int) {
+        if (child is MarkerView && child.excludeFromCluster) {
+            super.addFeature(child, index)
+            return
+        }
         val marker = child as MarkerView?
         val placemark = placemarksMap["" + marker!!.point!!.latitude + marker.point!!.longitude]
         if (placemark != null) {
@@ -178,6 +182,10 @@ class ClusteredYamapView(context: Context?) : YamapView(context), ClusterListene
     override fun removeChild(index: Int) {
         val child = getChildAt(index)
         if (child is MarkerView) {
+            if (child.excludeFromCluster) {
+                super.removeChild(index)
+                return
+            }
             val mapObject = child.rnMapObject
             if (mapObject == null || !mapObject.isValid) return
             clusterCollection.remove(mapObject)

--- a/android/src/main/java/ru/yamap/view/MarkerView.kt
+++ b/android/src/main/java/ru/yamap/view/MarkerView.kt
@@ -27,6 +27,8 @@ class MarkerView(context: Context?) : ReactViewGroup(context), MapObjectTapListe
     ReactMapObject {
     @JvmField
     var point: Point? = null
+    @JvmField
+    var excludeFromCluster: Boolean = false
     private var _zIndex = 1f
     private var _scale = 1f
     private var _visible = true
@@ -83,6 +85,10 @@ class MarkerView(context: Context?) : ReactViewGroup(context), MapObjectTapListe
     fun setAnchor(anchor: PointF?) {
         _markerAnchor = anchor
         updateMarker()
+    }
+
+    fun setExcludeFromCluster(value: Boolean) {
+        excludeFromCluster = value
     }
 
     private fun updateMarker() {

--- a/android/src/main/java/ru/yamap/view/MarkerViewManager.kt
+++ b/android/src/main/java/ru/yamap/view/MarkerViewManager.kt
@@ -64,6 +64,10 @@ class MarkerViewManager : ViewGroupManager<MarkerView>(), MarkerViewManagerInter
         view.setAnchor(pointF)
     }
 
+    override fun setExcludeFromCluster(view: MarkerView, value: Boolean) {
+        view.setExcludeFromCluster(value)
+    }
+
     override fun addView(parent: MarkerView, child: View, index: Int) {
         parent.addChildView(child, index)
     }

--- a/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
+++ b/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
@@ -59,6 +59,21 @@ class YamapViewManagerImpl() {
                 args.getArray("points"),
                 args.getString("id")
             )
+            "appendClusterMarkers" -> {
+                if (view is ClusteredYamapView) {
+                    @Suppress("UNCHECKED_CAST")
+                    val points = args.getArray("points")?.toArrayList()
+                        as? ArrayList<HashMap<String, Double>> ?: ArrayList()
+                    val iconSource = if (args.hasKey("iconSource") && !args.isNull("iconSource"))
+                        args.getString("iconSource") else null
+                    view.appendClusterMarkers(points, iconSource)
+                }
+            }
+            "clearClusterMarkers" -> {
+                if (view is ClusteredYamapView) {
+                    view.clearClusterMarkers()
+                }
+            }
 
             else -> throw IllegalArgumentException(
                 String.format(
@@ -233,6 +248,8 @@ class YamapViewManagerImpl() {
             "fitMarkers" to 7,
             "getScreenPoints" to 8,
             "getWorldPoints" to 9,
+            "appendClusterMarkers" to 10,
+            "clearClusterMarkers" to 11,
         )
     }
 }

--- a/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
+++ b/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
@@ -67,9 +67,13 @@ class YamapViewManagerImpl() {
                         as? ArrayList<HashMap<String, Double>> ?: ArrayList()
                     val iconSource = if (args.hasKey("iconSource") && !args.isNull("iconSource"))
                         args.getString("iconSource") else null
+                    val anchorX = if (args.hasKey("anchorX") && !args.isNull("anchorX"))
+                        args.getDouble("anchorX").toFloat() else null
+                    val anchorY = if (args.hasKey("anchorY") && !args.isNull("anchorY"))
+                        args.getDouble("anchorY").toFloat() else null
                     val recluster = if (args.hasKey("recluster") && !args.isNull("recluster"))
                         args.getBoolean("recluster") else true
-                    view.appendClusterMarkers(points, iconSource, recluster)
+                    view.appendClusterMarkers(points, iconSource, anchorX, anchorY, recluster)
                 }
             }
             "clearClusterMarkers" -> {

--- a/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
+++ b/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
@@ -13,6 +13,7 @@ import ru.yamap.events.yamap.GetScreenToWorldPointsEvent
 import ru.yamap.events.yamap.GetVisibleRegionEvent
 import ru.yamap.events.yamap.GetWorldToScreenPointsEvent
 import ru.yamap.events.yamap.MapLoadedEvent
+import ru.yamap.events.yamap.YamapClusterPlacemarkPressEvent
 import ru.yamap.events.yamap.YamapLongPressEvent
 import ru.yamap.events.yamap.YamapPressEvent
 import ru.yamap.utils.PointUtil
@@ -219,6 +220,8 @@ class YamapViewManagerImpl() {
                     mapOf("phasedRegistrationNames" to mapOf("bubbled" to "onMapPress")),
             YamapLongPressEvent.EVENT_NAME to
                     mapOf("phasedRegistrationNames" to mapOf("bubbled" to "onMapLongPress")),
+            YamapClusterPlacemarkPressEvent.EVENT_NAME to
+                    mapOf("phasedRegistrationNames" to mapOf("bubbled" to "onClusterPlacemarkPress")),
         )
 
         val exportedCustomDirectEventTypeConstants = mutableMapOf(

--- a/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
+++ b/android/src/main/java/ru/yamap/view/YamapViewManagerImpl.kt
@@ -66,7 +66,9 @@ class YamapViewManagerImpl() {
                         as? ArrayList<HashMap<String, Double>> ?: ArrayList()
                     val iconSource = if (args.hasKey("iconSource") && !args.isNull("iconSource"))
                         args.getString("iconSource") else null
-                    view.appendClusterMarkers(points, iconSource)
+                    val recluster = if (args.hasKey("recluster") && !args.isNull("recluster"))
+                        args.getBoolean("recluster") else true
+                    view.appendClusterMarkers(points, iconSource, recluster)
                 }
             }
             "clearClusterMarkers" -> {

--- a/ios/View/MarkerView.h
+++ b/ios/View/MarkerView.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (YMKPlacemarkMapObject*)getMapObject;
 - (void)setMapObject:(YMKPlacemarkMapObject*)mapObject;
 - (void)setClusterMapObject:(YMKPlacemarkMapObject*)mapObject;
+- (BOOL)excludeFromCluster;
 
 @end
 

--- a/ios/View/MarkerView.mm
+++ b/ios/View/MarkerView.mm
@@ -34,6 +34,7 @@ using namespace facebook::react;
     NSValue *anchor;
     BOOL visible;
     BOOL handled;
+    BOOL excludeFromCluster;
     NSMutableArray<UIView*> *_reactSubviews;
     YRTViewProvider *_markerViewProvider;
 }
@@ -48,6 +49,7 @@ using namespace facebook::react;
         rotated = NO;
         visible = YES;
         handled = NO;
+        excludeFromCluster = NO;
         _reactSubviews = [[NSMutableArray alloc] init];
         source = @"";
         lastSource = @"";
@@ -88,6 +90,7 @@ using namespace facebook::react;
     visible = newViewProps.visible;
     rotated = newViewProps.rotated;
     handled = newViewProps.handled;
+    excludeFromCluster = newViewProps.excludeFromCluster;
 
     [self updateMarker];
 }
@@ -114,9 +117,14 @@ using namespace facebook::react;
     rotated = NO;
     visible = YES;
     handled = NO;
+    excludeFromCluster = NO;
     source = nil;
     lastSource = nil;
     _reactSubviews = [[NSMutableArray alloc] init];
+}
+
+- (BOOL)excludeFromCluster {
+    return excludeFromCluster;
 }
 
 - (BOOL)onMapObjectTapWithMapObject:(nonnull YMKMapObject*)_mapObject point:(nonnull YMKPoint*)point {

--- a/ios/View/YamapView.h
+++ b/ios/View/YamapView.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setClusterTextSize:(double)size;
 - (void)setClusterTextXOffset:(double)size;
 - (void)setClusterTextYOffset:(double)size;
+- (void)appendClusterMarkers:(NSArray<YMKPoint *> *)points iconSource:(NSString * _Nullable)iconSource;
+- (void)clearClusterMarkers;
 
 // REF
 

--- a/ios/View/YamapView.h
+++ b/ios/View/YamapView.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setClusterTextSize:(double)size;
 - (void)setClusterTextXOffset:(double)size;
 - (void)setClusterTextYOffset:(double)size;
-- (void)appendClusterMarkers:(NSArray<YMKPoint *> *)points iconSource:(NSString * _Nullable)iconSource;
+- (void)appendClusterMarkers:(NSArray<YMKPoint *> *)points iconSource:(NSString * _Nullable)iconSource recluster:(BOOL)recluster;
 - (void)clearClusterMarkers;
 
 // REF

--- a/ios/View/YamapView.h
+++ b/ios/View/YamapView.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setClusterTextSize:(double)size;
 - (void)setClusterTextXOffset:(double)size;
 - (void)setClusterTextYOffset:(double)size;
-- (void)appendClusterMarkers:(NSArray<YMKPoint *> *)points iconSource:(NSString * _Nullable)iconSource recluster:(BOOL)recluster;
+- (void)appendClusterMarkers:(NSArray<YMKPoint *> *)points iconSource:(NSString * _Nullable)iconSource anchorX:(NSNumber * _Nullable)anchorX anchorY:(NSNumber * _Nullable)anchorY recluster:(BOOL)recluster;
 - (void)clearClusterMarkers;
 
 // REF

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -404,8 +404,16 @@ using namespace facebook::react;
             iconSource = nil;
         }
         id reclusterArg = args[0][0][@"recluster"];
+        NSNumber *anchorX = args[0][0][@"anchorX"];
+        NSNumber *anchorY = args[0][0][@"anchorY"];
         BOOL recluster = (reclusterArg == nil || [reclusterArg isEqual:[NSNull null]]) ? YES : [reclusterArg boolValue];
-        [self appendClusterMarkers:points iconSource:iconSource recluster:recluster];
+        if ([anchorX isEqual:[NSNull null]]) {
+            anchorX = nil;
+        }
+        if ([anchorY isEqual:[NSNull null]]) {
+            anchorY = nil;
+        }
+        [self appendClusterMarkers:points iconSource:iconSource anchorX:anchorX anchorY:anchorY recluster:recluster];
     } else if ([commandName isEqual:@"clearClusterMarkers"]) {
         [self clearClusterMarkers];
     }
@@ -883,7 +891,7 @@ using namespace facebook::react;
     [self clusterPlacemarks];
 }
 
-- (void)appendClusterMarkers:(NSArray<YMKPoint*>*)points iconSource:(NSString*)iconSource recluster:(BOOL)recluster {
+- (void)appendClusterMarkers:(NSArray<YMKPoint*>*)points iconSource:(NSString*)iconSource anchorX:(NSNumber*)anchorX anchorY:(NSNumber*)anchorY recluster:(BOOL)recluster {
     if (![self isKindOfClass:[ClusteredYamapView class]]) return;
     if (points == nil || [points count] == 0) return;
     if (![clusterCollection isValid]) {
@@ -895,7 +903,11 @@ using namespace facebook::react;
         __typeof__(self) strongSelf = weakSelf;
         if (!strongSelf) return;
         UIImage *effectiveImage = image ?: [strongSelf clusterImage:@(1)];
-        NSArray<YMKPlacemarkMapObject *> *added = [strongSelf->clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];
+        YMKIconStyle *iconStyle = [YMKIconStyle new];
+        if (anchorX != nil && anchorY != nil) {
+            [iconStyle setAnchor:[NSValue valueWithCGPoint:CGPointMake(anchorX.doubleValue, anchorY.doubleValue)]];
+        }
+        NSArray<YMKPlacemarkMapObject *> *added = [strongSelf->clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:iconStyle];
         [strongSelf->clusterPlacemarks addObjectsFromArray:added];
         for (YMKPlacemarkMapObject *pm in added) {
             NSValue *key = [NSValue valueWithNonretainedObject:pm];

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -392,6 +392,15 @@ using namespace facebook::react;
                 .worldPoints = worldPoints
             });
         }
+    } else if ([commandName isEqual:@"appendClusterMarkers"]) {
+        NSArray *points = [RCTConvert YMKPointArray:args[0][0][@"points"]];
+        NSString *iconSource = args[0][0][@"iconSource"];
+        if ([iconSource isEqual:[NSNull null]]) {
+            iconSource = nil;
+        }
+        [self appendClusterMarkers:points iconSource:iconSource];
+    } else if ([commandName isEqual:@"clearClusterMarkers"]) {
+        [self clearClusterMarkers];
     }
 }
 
@@ -852,6 +861,37 @@ using namespace facebook::react;
     }
 
     [self clusterPlacemarks];
+}
+
+- (void)appendClusterMarkers:(NSArray<YMKPoint*>*)points iconSource:(NSString*)iconSource {
+    if (![self isKindOfClass:[ClusteredYamapView class]]) return;
+    if (points == nil || [points count] == 0) return;
+    if (![clusterCollection isValid]) {
+        clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
+    }
+
+    void (^addBlock)(UIImage *) = ^(UIImage *image) {
+        UIImage *effectiveImage = image ?: [self clusterImage:@([points count])];
+        NSArray<YMKPlacemarkMapObject *> *added = [clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];
+        [clusterPlacemarks addObjectsFromArray:added];
+        [self clusterPlacemarks];
+    };
+
+    if (iconSource && [iconSource length] > 0) {
+        [[ImageCacheManager instance] getWithSource:iconSource completion:^(UIImage *image) {
+            addBlock(image);
+        }];
+    } else {
+        addBlock(nil);
+    }
+}
+
+- (void)clearClusterMarkers {
+    if (![self isKindOfClass:[ClusteredYamapView class]]) return;
+    [clusterPlacemarks removeAllObjects];
+    if ([clusterCollection isValid]) {
+        [clusterCollection clear];
+    }
 }
 
 -(UIImage*)clusterImage:(NSNumber*) clusterSize {

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -878,9 +878,9 @@ using namespace facebook::react;
         clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
     }
 
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     void (^addBlock)(UIImage *) = ^(UIImage *image) {
-        typeof(self) strongSelf = weakSelf;
+        __typeof__(self) strongSelf = weakSelf;
         if (!strongSelf) return;
         UIImage *effectiveImage = image ?: [strongSelf clusterImage:@(1)];
         NSArray<YMKPlacemarkMapObject *> *added = [strongSelf->clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -63,6 +63,7 @@ using namespace facebook::react;
     NSMutableArray<YMKPlacemarkMapObject *> *clusterPlacemarks;
     YMKClusterizedPlacemarkCollection *clusterCollection;
     BOOL mapLoaded;
+    BOOL hasImperativePlacemarks;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -398,7 +399,9 @@ using namespace facebook::react;
         if ([iconSource isEqual:[NSNull null]]) {
             iconSource = nil;
         }
-        [self appendClusterMarkers:points iconSource:iconSource];
+        id reclusterArg = args[0][0][@"recluster"];
+        BOOL recluster = (reclusterArg == nil || [reclusterArg isEqual:[NSNull null]]) ? YES : [reclusterArg boolValue];
+        [self appendClusterMarkers:points iconSource:iconSource recluster:recluster];
     } else if ([commandName isEqual:@"clearClusterMarkers"]) {
         [self clearClusterMarkers];
     }
@@ -842,6 +845,10 @@ using namespace facebook::react;
 }
 
 - (void)setClusteredMarkers:(NSArray<YMKPoint*>*) markers {
+    // Empty prop arrives on every re-render when the consumer drives this
+    // component imperatively — never clear in that case, it would wipe the
+    // markers added via appendClusterMarkers.
+    if ((markers == nil || [markers count] == 0) && hasImperativePlacemarks) return;
     [clusterPlacemarks removeAllObjects];
     if (![clusterCollection isValid]) {
         clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
@@ -859,22 +866,29 @@ using namespace facebook::react;
             }
         }
     }
+    hasImperativePlacemarks = NO;
 
     [self clusterPlacemarks];
 }
 
-- (void)appendClusterMarkers:(NSArray<YMKPoint*>*)points iconSource:(NSString*)iconSource {
+- (void)appendClusterMarkers:(NSArray<YMKPoint*>*)points iconSource:(NSString*)iconSource recluster:(BOOL)recluster {
     if (![self isKindOfClass:[ClusteredYamapView class]]) return;
     if (points == nil || [points count] == 0) return;
     if (![clusterCollection isValid]) {
         clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
     }
 
+    __weak typeof(self) weakSelf = self;
     void (^addBlock)(UIImage *) = ^(UIImage *image) {
-        UIImage *effectiveImage = image ?: [self clusterImage:@([points count])];
-        NSArray<YMKPlacemarkMapObject *> *added = [clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];
-        [clusterPlacemarks addObjectsFromArray:added];
-        [self clusterPlacemarks];
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        UIImage *effectiveImage = image ?: [strongSelf clusterImage:@(1)];
+        NSArray<YMKPlacemarkMapObject *> *added = [strongSelf->clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];
+        [strongSelf->clusterPlacemarks addObjectsFromArray:added];
+        strongSelf->hasImperativePlacemarks = YES;
+        if (recluster) {
+            [strongSelf clusterPlacemarks];
+        }
     };
 
     if (iconSource && [iconSource length] > 0) {
@@ -892,6 +906,7 @@ using namespace facebook::react;
     if ([clusterCollection isValid]) {
         [clusterCollection clear];
     }
+    hasImperativePlacemarks = NO;
 }
 
 -(UIImage*)clusterImage:(NSNumber*) clusterSize {

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -740,7 +740,8 @@ using namespace facebook::react;
         [polyline setMapObject:obj];
     } else if ([subview isKindOfClass:[MarkerView class]]) {
         MarkerView *marker = (MarkerView *) subview;
-        if ([self isKindOfClass:[ClusteredYamapView class]]) {
+        BOOL inClusterHost = [self isKindOfClass:[ClusteredYamapView class]];
+        if (inClusterHost && ![marker excludeFromCluster]) {
             if (index<[clusterPlacemarks count]) {
                 [marker setClusterMapObject:[clusterPlacemarks objectAtIndex:index]];
             }
@@ -780,9 +781,10 @@ using namespace facebook::react;
         YMKMapObjectCollection *objects = mapView.mapWindow.map.mapObjects;
         MarkerView *marker = (MarkerView *) subview;
         YMKPlacemarkMapObject *mapObject = [marker getMapObject];
-        if ([self isKindOfClass:[ClusteredYamapView class]]) {
+        BOOL inClusterHost = [self isKindOfClass:[ClusteredYamapView class]];
+        if (inClusterHost && ![marker excludeFromCluster]) {
             [clusterPlacemarks removeObject:mapObject];
-        } else {
+        } else if (mapObject != nil && [mapObject isValid]) {
             [objects removeWithMapObject:mapObject];
         }
     } else if ([subview isKindOfClass:[CircleView class]]) {

--- a/ios/View/YamapView.mm
+++ b/ios/View/YamapView.mm
@@ -25,7 +25,7 @@
 
 using namespace facebook::react;
 
-@interface YamapView () <YMKUserLocationObjectListener, YMKMapCameraListener, YMKMapLoadedListener, YMKTrafficDelegate, YMKClusterListener, YMKClusterTapListener>
+@interface YamapView () <YMKUserLocationObjectListener, YMKMapCameraListener, YMKMapLoadedListener, YMKTrafficDelegate, YMKClusterListener, YMKClusterTapListener, YMKMapObjectTapListener>
 
 @end
 
@@ -64,6 +64,8 @@ using namespace facebook::react;
     YMKClusterizedPlacemarkCollection *clusterCollection;
     BOOL mapLoaded;
     BOOL hasImperativePlacemarks;
+    NSMutableDictionary<NSValue *, NSNumber *> *imperativeIndexMap;
+    NSInteger imperativePlacemarkCounter;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -89,6 +91,8 @@ using namespace facebook::react;
         [mapView.mapWindow.map setMapLoadedListenerWithMapLoadedListener:self];
         initializedRegion = NO;
         clusterPlacemarks = [[NSMutableArray alloc] init];
+        imperativeIndexMap = [[NSMutableDictionary alloc] init];
+        imperativePlacemarkCounter = 0;
         clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
         clusterColor = UIColor.redColor;
         mapLoaded = NO;
@@ -412,6 +416,10 @@ using namespace facebook::react;
     [super prepareForRecycle];
 
     [self removeAllSections];
+    [clusterPlacemarks removeAllObjects];
+    [imperativeIndexMap removeAllObjects];
+    imperativePlacemarkCounter = 0;
+    hasImperativePlacemarks = NO;
 
     static const auto defaultProps = std::make_shared<const YamapViewProps>();
     _props = defaultProps;
@@ -852,6 +860,8 @@ using namespace facebook::react;
     // markers added via appendClusterMarkers.
     if ((markers == nil || [markers count] == 0) && hasImperativePlacemarks) return;
     [clusterPlacemarks removeAllObjects];
+    [imperativeIndexMap removeAllObjects];
+    imperativePlacemarkCounter = 0;
     if (![clusterCollection isValid]) {
         clusterCollection = [mapView.mapWindow.map.mapObjects addClusterizedPlacemarkCollectionWithClusterListener:self];
     }
@@ -887,6 +897,11 @@ using namespace facebook::react;
         UIImage *effectiveImage = image ?: [strongSelf clusterImage:@(1)];
         NSArray<YMKPlacemarkMapObject *> *added = [strongSelf->clusterCollection addPlacemarksWithPoints:points image:effectiveImage style:[YMKIconStyle new]];
         [strongSelf->clusterPlacemarks addObjectsFromArray:added];
+        for (YMKPlacemarkMapObject *pm in added) {
+            NSValue *key = [NSValue valueWithNonretainedObject:pm];
+            strongSelf->imperativeIndexMap[key] = @(strongSelf->imperativePlacemarkCounter++);
+            [pm addTapListenerWithTapListener:strongSelf];
+        }
         strongSelf->hasImperativePlacemarks = YES;
         if (recluster) {
             [strongSelf clusterPlacemarks];
@@ -905,6 +920,8 @@ using namespace facebook::react;
 - (void)clearClusterMarkers {
     if (![self isKindOfClass:[ClusteredYamapView class]]) return;
     [clusterPlacemarks removeAllObjects];
+    [imperativeIndexMap removeAllObjects];
+    imperativePlacemarkCounter = 0;
     if ([clusterCollection isValid]) {
         [clusterCollection clear];
     }
@@ -1017,6 +1034,25 @@ using namespace facebook::react;
         [lastKnownMarkers addObject:[placemark geometry]];
     }
     [self fitMarkers:lastKnownMarkers duration:0.7 animation:0];
+    return YES;
+}
+
+- (BOOL)onMapObjectTapWithMapObject:(nonnull YMKMapObject *)mapObject point:(nonnull YMKPoint *)point {
+    if (![mapObject isKindOfClass:[YMKPlacemarkMapObject class]]) {
+        return NO;
+    }
+    NSValue *key = [NSValue valueWithNonretainedObject:mapObject];
+    NSNumber *idx = imperativeIndexMap[key];
+    if (idx == nil) {
+        return NO;
+    }
+    if (_eventEmitter && [self isKindOfClass:[ClusteredYamapView class]]) {
+        std::dynamic_pointer_cast<const ClusteredYamapViewEventEmitter>(_eventEmitter)->onClusterPlacemarkPress({
+            .lat = point.latitude,
+            .lon = point.longitude,
+            .index = [idx intValue],
+        });
+    }
     return YES;
 }
 

--- a/src/components/ClusteredYamap/ClusteredYamap.tsx
+++ b/src/components/ClusteredYamap/ClusteredYamap.tsx
@@ -22,8 +22,10 @@ export const ClusteredYamap = forwardRef<YamapRef, ClusteredYamapProps>(({
 
   useYamap(nativeRef, ref, Commands);
 
-  const nativeProps = useMemo(() =>
-    processColorsToNative({
+  const nativeProps = useMemo(() => {
+    const markers = props.clusteredMarkers ?? [];
+    const renderMarker = props.renderMarker;
+    return processColorsToNative({
       ...props,
       onCameraPositionReceived,
       onVisibleRegionReceived,
@@ -32,7 +34,7 @@ export const ClusteredYamap = forwardRef<YamapRef, ClusteredYamapProps>(({
       userLocationIcon: getImageUri(props.userLocationIcon),
       clusterIcon: getImageUri(props.clusterIcon),
       clusterColor,
-      clusteredMarkers: props.clusteredMarkers.map(mark => mark.point),
+      clusteredMarkers: markers.map(mark => mark.point),
       clusterSize: props.clusterSize ? {
         width:  props.clusterSize.width
           ? PixelRatio.getPixelSizeForLayoutSize(props.clusterSize.width)
@@ -50,13 +52,14 @@ export const ClusteredYamap = forwardRef<YamapRef, ClusteredYamapProps>(({
       clusterTextXOffset: props.clusterTextXOffset
         ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextXOffset)
         : props.clusterTextXOffset,
-      children: props.clusteredMarkers.map(props.renderMarker),
+      children: renderMarker ? markers.map(renderMarker) : undefined,
     }, [
       'clusterColor',
       'userLocationAccuracyFillColor',
       'userLocationAccuracyStrokeColor',
       'clusterTextColor'
-    ]),
+    ]);
+  },
     [clusterColor, props]
   );
 

--- a/src/components/ClusteredYamap/ClusteredYamap.tsx
+++ b/src/components/ClusteredYamap/ClusteredYamap.tsx
@@ -1,22 +1,23 @@
-import React, {forwardRef, useMemo, useRef} from 'react';
-import {PixelRatio} from "react-native";
-import {getImageUri, processColorsToNative} from '../../utils';
+import React, { forwardRef, useMemo, useRef } from "react";
+import { PixelRatio } from "react-native";
+import { getImageUri, processColorsToNative } from "../../utils";
 import {
   onCameraPositionReceived,
   onScreenToWorldPointsReceived,
   onVisibleRegionReceived,
   onWorldToScreenPointsReceived,
-} from '../Yamap/events';
-import {type ClusteredYamapProps, type ClusteredYamapRef} from './types';
-import ClusteredYamapNativeComponent, {type ClusteredYamapNativeRef} from '../../spec/ClusteredYamapNativeComponent';
-import {useClusteredYamap} from '../../hooks/useYamap';
-import {Commands} from '../../spec/commands/yamap';
+} from "../Yamap/events";
+import { type ClusteredYamapProps, type ClusteredYamapRef } from "./types";
+import ClusteredYamapNativeComponent, {
+  type ClusteredYamapNativeRef,
+} from "../../spec/ClusteredYamapNativeComponent";
+import { useClusteredYamap } from "../../hooks/useYamap";
+import { Commands } from "../../spec/commands/yamap";
 
-export const ClusteredYamap = forwardRef<ClusteredYamapRef, ClusteredYamapProps>(({
-    clusterColor = 'red',
-    ...props
-  }, ref) => {
-
+export const ClusteredYamap = forwardRef<
+  ClusteredYamapRef,
+  ClusteredYamapProps
+>(({ clusterColor = "red", ...props }, ref) => {
   const nativeRef = useRef<ClusteredYamapNativeRef | null>(null);
 
   useClusteredYamap(nativeRef, ref, Commands);
@@ -24,48 +25,48 @@ export const ClusteredYamap = forwardRef<ClusteredYamapRef, ClusteredYamapProps>
   const nativeProps = useMemo(() => {
     const markers = props.clusteredMarkers ?? [];
     const renderMarker = props.renderMarker;
-    return processColorsToNative({
-      ...props,
-      onCameraPositionReceived,
-      onVisibleRegionReceived,
-      onWorldToScreenPointsReceived,
-      onScreenToWorldPointsReceived,
-      userLocationIcon: getImageUri(props.userLocationIcon),
-      clusterIcon: getImageUri(props.clusterIcon),
-      clusterColor,
-      clusteredMarkers: markers.map(mark => mark.point),
-      clusterSize: props.clusterSize ? {
-        width:  props.clusterSize.width
-          ? PixelRatio.getPixelSizeForLayoutSize(props.clusterSize.width)
-          : props.clusterSize.width,
-        height: props.clusterSize.height
-          ? PixelRatio.getPixelSizeForLayoutSize(props.clusterSize.height)
-          : props.clusterSize.height,
-      } : props.clusterSize,
-      clusterTextSize: props.clusterTextSize
-        ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextSize)
-        : props.clusterTextSize,
-      clusterTextYOffset: props.clusterTextYOffset
-        ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextYOffset)
-        : props.clusterTextYOffset,
-      clusterTextXOffset: props.clusterTextXOffset
-        ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextXOffset)
-        : props.clusterTextXOffset,
-      children: renderMarker ? markers.map(renderMarker) : undefined,
-    }, [
-      'clusterColor',
-      'userLocationAccuracyFillColor',
-      'userLocationAccuracyStrokeColor',
-      'clusterTextColor'
-    ]);
-  },
-    [clusterColor, props]
-  );
+    return processColorsToNative(
+      {
+        ...props,
+        onCameraPositionReceived,
+        onVisibleRegionReceived,
+        onWorldToScreenPointsReceived,
+        onScreenToWorldPointsReceived,
+        userLocationIcon: getImageUri(props.userLocationIcon),
+        clusterIcon: getImageUri(props.clusterIcon),
+        clusterColor,
+        clusteredMarkers: markers.map((mark) => mark.point),
+        clusterSize: props.clusterSize
+          ? {
+              width: props.clusterSize.width
+                ? PixelRatio.getPixelSizeForLayoutSize(props.clusterSize.width)
+                : props.clusterSize.width,
+              height: props.clusterSize.height
+                ? PixelRatio.getPixelSizeForLayoutSize(props.clusterSize.height)
+                : props.clusterSize.height,
+            }
+          : props.clusterSize,
+        clusterTextSize: props.clusterTextSize
+          ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextSize)
+          : props.clusterTextSize,
+        clusterTextYOffset: props.clusterTextYOffset
+          ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextYOffset)
+          : props.clusterTextYOffset,
+        clusterTextXOffset: props.clusterTextXOffset
+          ? PixelRatio.getPixelSizeForLayoutSize(props.clusterTextXOffset)
+          : props.clusterTextXOffset,
+        children: renderMarker
+          ? [props.children, ...markers.map(renderMarker)]
+          : props.children,
+      },
+      [
+        "clusterColor",
+        "userLocationAccuracyFillColor",
+        "userLocationAccuracyStrokeColor",
+        "clusterTextColor",
+      ],
+    );
+  }, [clusterColor, props]);
 
-  return (
-    <ClusteredYamapNativeComponent
-      {...nativeProps}
-      ref={nativeRef}
-    />
-  );
+  return <ClusteredYamapNativeComponent {...nativeProps} ref={nativeRef} />;
 });

--- a/src/components/ClusteredYamap/ClusteredYamap.tsx
+++ b/src/components/ClusteredYamap/ClusteredYamap.tsx
@@ -7,20 +7,19 @@ import {
   onVisibleRegionReceived,
   onWorldToScreenPointsReceived,
 } from '../Yamap/events';
-import {type ClusteredYamapProps} from './types';
+import {type ClusteredYamapProps, type ClusteredYamapRef} from './types';
 import ClusteredYamapNativeComponent, {type ClusteredYamapNativeRef} from '../../spec/ClusteredYamapNativeComponent';
-import {useYamap} from '../../hooks/useYamap';
-import {type YamapRef} from '../Yamap/types';
+import {useClusteredYamap} from '../../hooks/useYamap';
 import {Commands} from '../../spec/commands/yamap';
 
-export const ClusteredYamap = forwardRef<YamapRef, ClusteredYamapProps>(({
+export const ClusteredYamap = forwardRef<ClusteredYamapRef, ClusteredYamapProps>(({
     clusterColor = 'red',
     ...props
   }, ref) => {
 
   const nativeRef = useRef<ClusteredYamapNativeRef | null>(null);
 
-  useYamap(nativeRef, ref, Commands);
+  useClusteredYamap(nativeRef, ref, Commands);
 
   const nativeProps = useMemo(() => {
     const markers = props.clusteredMarkers ?? [];

--- a/src/components/ClusteredYamap/types.ts
+++ b/src/components/ClusteredYamap/types.ts
@@ -3,6 +3,26 @@ import {type ImageSourcePropType} from 'react-native';
 import type {Point} from "../";
 import {type OmitEx} from '../../utils';
 import type {ClusteredYamapNativeProps, YandexClusterSizes} from '../../spec/ClusteredYamapNativeComponent';
+import type {YamapRef} from '../Yamap/types';
+
+export type AppendClusterMarkersOptions = {
+  /** Per-marker icon. Resolved to a URI internally. If omitted, a neutral placeholder is used. */
+  iconSource?: ImageSourcePropType;
+  /**
+   * Whether to run the clustering pass after adding points. Defaults to `true`.
+   * Pass `false` for intermediate batches when streaming many appends and call
+   * once more with the default for the final batch to avoid O(total) clustering
+   * work on every append.
+   */
+  recluster?: boolean;
+};
+
+export type ClusteredYamapRef = YamapRef & {
+  /** Append points to the cluster collection without clearing existing ones. */
+  appendClusterMarkers: (points: Point[], options?: AppendClusterMarkersOptions) => void;
+  /** Remove all imperatively-added points from the cluster collection. */
+  clearClusterMarkers: () => void;
+};
 
 export type ClusteredYamapProps<T = any> = OmitEx<ClusteredYamapNativeProps,
   'userLocationAccuracyFillColor' |

--- a/src/components/ClusteredYamap/types.ts
+++ b/src/components/ClusteredYamap/types.ts
@@ -21,12 +21,17 @@ export type ClusteredYamapProps<T = any> = OmitEx<ClusteredYamapNativeProps,
   userLocationAccuracyFillColor?: string;
   userLocationAccuracyStrokeColor?: string;
   userLocationIcon?: ImageSourcePropType;
-  clusteredMarkers: ReadonlyArray<{point: Point, data: T}>
+  /**
+   * Prop-based cluster markers. Optional — you can also drive the cluster
+   * collection imperatively via `ref.current.appendClusterMarkers(...)`.
+   */
+  clusteredMarkers?: ReadonlyArray<{point: Point, data: T}>
   clusterIcon?: ImageSourcePropType;
   clusterSize?: YandexClusterSizes;
   clusterTextSize?: number;
   clusterTextYOffset?: number;
   clusterTextXOffset?: number;
   clusterTextColor?: string;
-  renderMarker: (info: {point: Point, data: T}, index: number) => React.ReactElement
+  /** Required only when `clusteredMarkers` is provided. */
+  renderMarker?: (info: {point: Point, data: T}, index: number) => React.ReactElement
 }

--- a/src/components/ClusteredYamap/types.ts
+++ b/src/components/ClusteredYamap/types.ts
@@ -9,6 +9,14 @@ export type AppendClusterMarkersOptions = {
   /** Per-marker icon. Resolved to a URI internally. If omitted, a neutral placeholder is used. */
   iconSource?: ImageSourcePropType;
   /**
+   * Icon anchor in image-relative space. (0.5, 0.5) = center, (0.5, 1) =
+   * bottom-center (e.g. tail-tip of a pin). Values outside 0..1 are passed
+   * through to Yandex MapKit. Applied as the `YMKIconStyle` anchor for every
+   * placemark in this append batch. Defaults to Yandex's built-in (0.5, 0.5)
+   * when omitted.
+   */
+  anchor?: { x: number; y: number };
+  /**
    * Whether to run the clustering pass after adding points. Defaults to `true`.
    * Pass `false` for intermediate batches when streaming many appends and call
    * once more with the default for the final batch to avoid O(total) clustering

--- a/src/components/ClusteredYamap/types.ts
+++ b/src/components/ClusteredYamap/types.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-import {type ImageSourcePropType} from 'react-native';
+import {type ImageSourcePropType, type NativeSyntheticEvent} from 'react-native';
 import type {Point} from "../";
 import {type OmitEx} from '../../utils';
-import type {ClusteredYamapNativeProps, YandexClusterSizes} from '../../spec/ClusteredYamapNativeComponent';
+import type {ClusterPlacemarkPress, ClusteredYamapNativeProps, YandexClusterSizes} from '../../spec/ClusteredYamapNativeComponent';
 import type {YamapRef} from '../Yamap/types';
 
 export type AppendClusterMarkersOptions = {
@@ -35,7 +35,8 @@ export type ClusteredYamapProps<T = any> = OmitEx<ClusteredYamapNativeProps,
   'onCameraPositionReceived' |
   'onVisibleRegionReceived' |
   'onWorldToScreenPointsReceived' |
-  'onScreenToWorldPointsReceived'
+  'onScreenToWorldPointsReceived' |
+  'onClusterPlacemarkPress'
 > & {
   clusterColor?: string;
   userLocationAccuracyFillColor?: string;
@@ -54,4 +55,13 @@ export type ClusteredYamapProps<T = any> = OmitEx<ClusteredYamapNativeProps,
   clusterTextColor?: string;
   /** Required only when `clusteredMarkers` is provided. */
   renderMarker?: (info: {point: Point, data: T}, index: number) => React.ReactElement
+  /**
+   * Fires when the user taps a placemark added via
+   * `ref.current.appendClusterMarkers(...)`. Does not fire for clusters of
+   * size ≥ 2 (those go to the cluster collapse handler) and does not fire
+   * for `<Marker>` children. `index` is the zero-based append-order index
+   * across all `appendClusterMarkers` batches; it resets after
+   * `clearClusterMarkers()`.
+   */
+  onClusterPlacemarkPress?: (event: NativeSyntheticEvent<ClusterPlacemarkPress>) => void
 }

--- a/src/components/Yamap/types.ts
+++ b/src/components/Yamap/types.ts
@@ -42,4 +42,13 @@ export type YamapRef = {
   setTrafficVisible: (isVisible: boolean) => void;
   getScreenPoints: (points: Point[], callback: ScreenPointsCallback) => void;
   getWorldPoints: (points: ScreenPoint[], callback: WorldPointsCallback) => void;
+  /**
+   * Append points to the cluster collection without clearing existing ones.
+   * Only takes effect on ClusteredYamap. Pass an ImageSourcePropType via
+   * iconSource to set the per-marker icon (resolved to a URI internally); if
+   * omitted, the library falls back to the cluster-style icon.
+   */
+  appendClusterMarkers: (points: Point[], iconSource?: ImageSourcePropType) => void;
+  /** Remove all points from the cluster collection. */
+  clearClusterMarkers: () => void;
 };

--- a/src/components/Yamap/types.ts
+++ b/src/components/Yamap/types.ts
@@ -42,13 +42,4 @@ export type YamapRef = {
   setTrafficVisible: (isVisible: boolean) => void;
   getScreenPoints: (points: Point[], callback: ScreenPointsCallback) => void;
   getWorldPoints: (points: ScreenPoint[], callback: WorldPointsCallback) => void;
-  /**
-   * Append points to the cluster collection without clearing existing ones.
-   * Only takes effect on ClusteredYamap. Pass an ImageSourcePropType via
-   * iconSource to set the per-marker icon (resolved to a URI internally); if
-   * omitted, the library falls back to the cluster-style icon.
-   */
-  appendClusterMarkers: (points: Point[], iconSource?: ImageSourcePropType) => void;
-  /** Remove all points from the cluster collection. */
-  clearClusterMarkers: () => void;
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,11 @@
 export {Circle, type CircleProps} from './Circle';
 
 export {ClusteredYamap} from './ClusteredYamap/ClusteredYamap';
-export {type ClusteredYamapProps} from './ClusteredYamap/types';
+export {
+  type ClusteredYamapProps,
+  type ClusteredYamapRef,
+  type AppendClusterMarkersOptions,
+} from './ClusteredYamap/types';
 
 export {Marker, type MarkerRef, type MarkerProps} from './Marker';
 

--- a/src/hooks/useYamap.ts
+++ b/src/hooks/useYamap.ts
@@ -2,47 +2,71 @@ import {type ForwardedRef, type RefObject, useImperativeHandle} from 'react';
 import {Animation} from '../interfaces';
 import {CallbacksManager, getImageUri} from '../utils';
 import {type YamapRef} from '../components';
+import {type ClusteredYamapRef} from '../components/ClusteredYamap/types';
 import {type YamapNativeCommands} from '../spec/commands/yamap';
 import {type YamapNativeRef} from '../spec/YamapNativeComponent';
+import {type ClusteredYamapNativeRef} from '../spec/ClusteredYamapNativeComponent';
+
+type AnyYamapNativeRef = YamapNativeRef | ClusteredYamapNativeRef;
+
+const buildBaseHandle = <R extends AnyYamapNativeRef>(
+  nativeRef: RefObject<R | null>,
+  nativeCommands: YamapNativeCommands,
+): YamapRef => ({
+  setCenter: (center, zoom = 10, azimuth = 0, tilt = 0, duration = 0, animation = Animation.SMOOTH) =>
+    nativeCommands.setCenter(nativeRef.current!, [{center, zoom, azimuth, tilt, duration, animation}]),
+  fitAllMarkers: (duration = 0.7, animation = Animation.SMOOTH) =>
+    nativeCommands.fitAllMarkers(nativeRef.current!, [{duration, animation}]),
+  fitMarkers: (points, duration = 0.7, animation = Animation.SMOOTH) =>
+    nativeCommands.fitMarkers(nativeRef.current!, [{points, duration, animation}]),
+  setTrafficVisible: (isVisible) =>
+    nativeCommands.setTrafficVisible(nativeRef.current!, [{isVisible}]),
+  setZoom: (zoom, duration = 0, animation = Animation.SMOOTH) =>
+    nativeCommands.setZoom(nativeRef.current!, [{zoom, duration, animation}]),
+  getCameraPosition: (callback) => {
+    const id = CallbacksManager.addCallback(callback);
+    nativeCommands.getCameraPosition(nativeRef.current!, [{id}]);
+  },
+  getVisibleRegion: (callback) => {
+    const id = CallbacksManager.addCallback(callback);
+    nativeCommands.getVisibleRegion(nativeRef.current!, [{id}]);
+  },
+  getScreenPoints: (points, callback) => {
+    const id = CallbacksManager.addCallback(callback);
+    nativeCommands.getScreenPoints(nativeRef.current!, [{points, id}]);
+  },
+  getWorldPoints: (points, callback) => {
+    const id = CallbacksManager.addCallback(callback);
+    nativeCommands.getWorldPoints(nativeRef.current!, [{points, id}]);
+  },
+});
 
 export const useYamap = (
   nativeRef: RefObject<YamapNativeRef | null>,
   ref: ForwardedRef<YamapRef>,
   nativeCommands: YamapNativeCommands,
 ) => {
+  useImperativeHandle(
+    ref,
+    () => buildBaseHandle(nativeRef, nativeCommands),
+    [nativeCommands, nativeRef],
+  );
+};
+
+export const useClusteredYamap = (
+  nativeRef: RefObject<ClusteredYamapNativeRef | null>,
+  ref: ForwardedRef<ClusteredYamapRef>,
+  nativeCommands: YamapNativeCommands,
+) => {
   useImperativeHandle(ref, () => ({
-    setCenter: (center, zoom = 10, azimuth = 0, tilt = 0, duration = 0, animation = Animation.SMOOTH) =>
-      nativeCommands.setCenter(nativeRef.current!, [{center, zoom, azimuth, tilt, duration, animation}]),
-    fitAllMarkers: (duration = 0.7, animation = Animation.SMOOTH) =>
-      nativeCommands.fitAllMarkers(nativeRef.current!, [{duration, animation}]),
-    fitMarkers: (points, duration = 0.7, animation = Animation.SMOOTH) =>
-      nativeCommands.fitMarkers(nativeRef.current!, [{points, duration, animation}]),
-    setTrafficVisible: (isVisible) =>
-      nativeCommands.setTrafficVisible(nativeRef.current!, [{isVisible}]),
-    setZoom: (zoom, duration = 0, animation = Animation.SMOOTH) =>
-      nativeCommands.setZoom(nativeRef.current!, [{zoom, duration, animation}]),
-    getCameraPosition: (callback) => {
-      const id = CallbacksManager.addCallback(callback);
-      nativeCommands.getCameraPosition(nativeRef.current!, [{id}]);
-    },
-    getVisibleRegion: (callback) => {
-      const id = CallbacksManager.addCallback(callback);
-      nativeCommands.getVisibleRegion(nativeRef.current!, [{id}]);
-    },
-    getScreenPoints: (points, callback) => {
-      const id = CallbacksManager.addCallback(callback);
-      nativeCommands.getScreenPoints(nativeRef.current!, [{points, id}]);
-    },
-    getWorldPoints: (points, callback) => {
-      const id = CallbacksManager.addCallback(callback);
-      nativeCommands.getWorldPoints(nativeRef.current!, [{points, id}]);
-    },
-    appendClusterMarkers: (points, iconSource) =>
-      nativeCommands.appendClusterMarkers(nativeRef.current! as any, [{
+    ...buildBaseHandle(nativeRef, nativeCommands),
+    appendClusterMarkers: (points, options) =>
+      nativeCommands.appendClusterMarkers(nativeRef.current!, [{
         points,
-        iconSource: getImageUri(iconSource),
+        iconSource: getImageUri(options?.iconSource),
+        recluster: options?.recluster ?? true,
       }]),
     clearClusterMarkers: () =>
-      nativeCommands.clearClusterMarkers(nativeRef.current! as any, [{}]),
+      nativeCommands.clearClusterMarkers(nativeRef.current!, [{}]),
   }), [nativeCommands, nativeRef]);
 };

--- a/src/hooks/useYamap.ts
+++ b/src/hooks/useYamap.ts
@@ -1,6 +1,6 @@
 import {type ForwardedRef, type RefObject, useImperativeHandle} from 'react';
 import {Animation} from '../interfaces';
-import {CallbacksManager} from '../utils';
+import {CallbacksManager, getImageUri} from '../utils';
 import {type YamapRef} from '../components';
 import {type YamapNativeCommands} from '../spec/commands/yamap';
 import {type YamapNativeRef} from '../spec/YamapNativeComponent';
@@ -37,5 +37,12 @@ export const useYamap = (
       const id = CallbacksManager.addCallback(callback);
       nativeCommands.getWorldPoints(nativeRef.current!, [{points, id}]);
     },
+    appendClusterMarkers: (points, iconSource) =>
+      nativeCommands.appendClusterMarkers(nativeRef.current! as any, [{
+        points,
+        iconSource: getImageUri(iconSource),
+      }]),
+    clearClusterMarkers: () =>
+      nativeCommands.clearClusterMarkers(nativeRef.current! as any, [{}]),
   }), [nativeCommands, nativeRef]);
 };

--- a/src/hooks/useYamap.ts
+++ b/src/hooks/useYamap.ts
@@ -64,6 +64,8 @@ export const useClusteredYamap = (
       nativeCommands.appendClusterMarkers(nativeRef.current!, [{
         points,
         iconSource: getImageUri(options?.iconSource),
+        anchorX: options?.anchor?.x,
+        anchorY: options?.anchor?.y,
         recluster: options?.recluster ?? true,
       }]),
     clearClusterMarkers: () =>

--- a/src/spec/ClusteredYamapNativeComponent.ts
+++ b/src/spec/ClusteredYamapNativeComponent.ts
@@ -101,6 +101,12 @@ export interface YandexClusterSizes {
   height?: Double;
 }
 
+export interface ClusterPlacemarkPress {
+  lat: Double;
+  lon: Double;
+  index: Int32;
+}
+
 export interface ClusteredYamapNativeProps extends ViewProps {
   userLocationIconScale?: Float;
   showUserPosition?: boolean;
@@ -140,6 +146,7 @@ export interface ClusteredYamapNativeProps extends ViewProps {
   clusterTextYOffset?: Int32;
   clusterTextXOffset?: Int32;
   clusterTextColor?: Int32;
+  onClusterPlacemarkPress?: BubblingEventHandler<ClusterPlacemarkPress>;
 }
 
 export type ClusteredYamapNativeRef = Component<ClusteredYamapNativeProps, {}, any> & Readonly<NativeMethods>

--- a/src/spec/MarkerNativeComponent.ts
+++ b/src/spec/MarkerNativeComponent.ts
@@ -24,6 +24,14 @@ export interface MarkerNativeProps extends ViewProps {
   handled?: boolean;
   source?: string;
   zI?: Float;
+  /**
+   * Only meaningful when this Marker is a child of ClusteredYamap.
+   * When true, the marker is added to the map's root object collection
+   * instead of the cluster collection — it stays visible on every zoom
+   * level and never merges into a cluster. Read once at mount; toggling
+   * at runtime has no effect.
+   */
+  excludeFromCluster?: boolean;
 }
 
 export type MarkerComponentType = NativeComponentType<MarkerNativeProps> & Readonly<MarkerNativeCommands>;

--- a/src/spec/commands/yamap.ts
+++ b/src/spec/commands/yamap.ts
@@ -74,11 +74,12 @@ export interface YamapNativeCommands {
     args: Array<Readonly<{
       points: Point[],
       iconSource?: string,
+      recluster?: boolean,
     }>>
   ) => void;
   clearClusterMarkers: (
     viewRef: React.ElementRef<ClusteredYamapComponentType>,
-    args: Array<Readonly<{}>>
+    args: Array<Readonly<Record<string, never>>>
   ) => void;
 }
 

--- a/src/spec/commands/yamap.ts
+++ b/src/spec/commands/yamap.ts
@@ -69,6 +69,17 @@ export interface YamapNativeCommands {
       id: string
     }>>
   ) => void;
+  appendClusterMarkers: (
+    viewRef: React.ElementRef<ClusteredYamapComponentType>,
+    args: Array<Readonly<{
+      points: Point[],
+      iconSource?: string,
+    }>>
+  ) => void;
+  clearClusterMarkers: (
+    viewRef: React.ElementRef<ClusteredYamapComponentType>,
+    args: Array<Readonly<{}>>
+  ) => void;
 }
 
 export const Commands = codegenNativeCommands<YamapNativeCommands>({
@@ -82,5 +93,7 @@ export const Commands = codegenNativeCommands<YamapNativeCommands>({
     'setTrafficVisible',
     'getScreenPoints',
     'getWorldPoints',
+    'appendClusterMarkers',
+    'clearClusterMarkers',
   ],
 });

--- a/src/spec/commands/yamap.ts
+++ b/src/spec/commands/yamap.ts
@@ -74,6 +74,8 @@ export interface YamapNativeCommands {
     args: Array<Readonly<{
       points: Point[],
       iconSource?: string,
+      anchorX?: Double,
+      anchorY?: Double,
       recluster?: boolean,
     }>>
   ) => void;


### PR DESCRIPTION
## Проблема

Единственный способ обновить маркеры кластера — проп `clusteredMarkers`, который на каждом изменении вызывает `clear` + `addPlacemarksWithPoints`. На практике `YMKClusterizedPlacemarkCollection.clear` не всегда удаляет уже отрисованные плейсмарки — в результате на карте появляются дубликаты (суммарный размер кластеров превышает фактическое число переданных точек).

Дополнительно: нет способа инкрементально добавлять точки по мере того, как пользователь исследует карту, — каждое обновление проходит через clear-and-reset, что вызывает мигание уже существующих маркеров.

## Решение

Две новые императивные команды на `ClusteredYamap`:

- **`appendClusterMarkers(points, iconSource?)`** — добавляет точки к коллекции без очистки. `iconSource` (опционально) — `ImageSourcePropType` для иконки отдельных маркеров, резолвится внутри через `Image.resolveAssetSource` и `ImageCacheManager` (так же, как `clusterIcon`).
- **`clearClusterMarkers()`** — явный сброс коллекции (удобно для смены фильтров).

Обе команды — no-op на обычной `YamapView`.

## Изменения API

- Новые команды в `src/spec/commands/yamap.ts` и в `YamapRef`.
- `clusteredMarkers` и `renderMarker` в `ClusteredYamapProps` стали опциональными, чтобы вызывающие через императивный API не обязаны были передавать заглушки.

## Обратная совместимость

- Проп-ориентированное API (`clusteredMarkers` + `renderMarker`) не изменилось и продолжает работать.
- ⚠️ На TS-уровне `clusteredMarkers` и `renderMarker` теперь `optional`. Код, читающий `props.clusteredMarkers.length` без проверки, нужно будет защитить `?.` или fallback на `[]`.

## Тестирование

Протестировано в продакшн-приложении с частыми delta-обновлениями при панорамировании карты: количество маркеров в кластерах теперь совпадает с реальным числом точек, существующие маркеры при добавлении новых не мигают.